### PR TITLE
Fix handling of column names with underscores

### DIFF
--- a/src/postgraphile-upsert.ts
+++ b/src/postgraphile-upsert.ts
@@ -261,7 +261,7 @@ const PgMutationUpsertPlugin: Plugin = builder => {
 
                   const uniqueKeyColumns = uniqueKeys
                     .map(attr => {
-                      const whereValue = where[attr.name]
+                      const whereValue = where[inflection.camelCase(attr.name)]
                       if (whereValue) {
                         return sql.fragment`${sql.identifier(attr.name)}`
                       }


### PR DESCRIPTION
This fixes handling of column names with underscores.  The `where` keys are camel cased, but the `attr` keys are not.