### PR TITLE
"fix undefined is not an object" when using omit on columns

### DIFF
--- a/src/postgraphile-upsert.ts
+++ b/src/postgraphile-upsert.ts
@@ -76,7 +76,7 @@ const PgMutationUpsertPlugin: Plugin = builder => {
               attributes.find(attr => attr.num === num)
             )
             if (keys.some(key => omit(key, 'read'))) {
-              return
+              return acc
             }
             if (!keys.every(_ => _)) {
               throw new Error('Consistency error: could not find an attribute!')


### PR DESCRIPTION
Rather trivial crash fix.

Thanks for the great plugin! 