### PR TITLE
Made PgMutationUpsertPlugin the default export

### DIFF
--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -2,7 +2,7 @@ import { container, DbContext } from './fixture/db'
 import { createPool } from './fixture/client'
 import { createServer, Server } from 'http'
 import { freeport } from './fixture/freeport'
-import { PgMutationUpsertPlugin } from '../postgraphile-upsert'
+import PgMutationUpsertPlugin from '../postgraphile-upsert'
 import { Pool } from 'pg'
 import { postgraphile } from 'postgraphile'
 import ava, { TestInterface } from 'ava'
@@ -98,7 +98,7 @@ test('test upsert crud', async t => {
     mutation {
       upsertBike(where: {
         serialNumber: "abc123"
-      }, 
+      },
       input: {
         bike: {
           serialNumber: "abc123"
@@ -119,7 +119,7 @@ test('test upsert crud', async t => {
     mutation {
       upsertBike(where: {
         serialNumber: "def456"
-      }, 
+      },
       input: {
         bike: {
           serialNumber: "def456"
@@ -140,7 +140,7 @@ test('test upsert crud', async t => {
     mutation {
       upsertBike(where: {
         serialNumber: "abc123"
-      }, 
+      },
       input: {
         bike: {
           serialNumber: "abc123"
@@ -211,7 +211,7 @@ test('test multi-column uniques', async t => {
       upsertRole(where: {
         project: "sales",
         title: "director"
-      }, 
+      },
       input: {
         role: {
           project: "sales",
@@ -233,7 +233,7 @@ test('test multi-column uniques', async t => {
       upsertRole(where: {
         project: "sales",
         title: "agent"
-      }, 
+      },
       input: {
         role: {
           project: "sales",
@@ -255,7 +255,7 @@ test('test multi-column uniques', async t => {
       upsertRole(where: {
         project: "sales",
         title: "director"
-      }, 
+      },
       input: {
         role: {
           project: "sales",

--- a/src/postgraphile-upsert.ts
+++ b/src/postgraphile-upsert.ts
@@ -314,4 +314,4 @@ const PgMutationUpsertPlugin: Plugin = builder => {
   })
 }
 
-export { PgMutationUpsertPlugin }
+export default PgMutationUpsertPlugin


### PR DESCRIPTION
General practice with Postgraphile plugins is for the plugin function to be the default export. This is the case for `@graphile/pg-pubsub`, `@graphile-contrib/pg-simplify-inflector`, `postgraphile-plugin-connection-filter`, etc:
```ts
import PgSimplifyInflectorPlugin from '@graphile-contrib/pg-simplify-inflector';
import PgPubsub from '@graphile/pg-pubsub';
import PgManyToMany from '@graphile-contrib/pg-many-to-many';
import PgFulltextFilter from '@lukeramsden/postgraphile-plugin-fulltext-filter';
import PgConnectionFilter from 'postgraphile-plugin-connection-filter';
// odd one out
import {PgMutationUpsertPlugin} from '@fullstackio/postgraphile-upsert-plugin';
```
This PR changes the export to simply export the Plugin as the default export. This is a breaking change and will require a `major` semver bump to 2.0.0. May be worth doing together along with any other breaking changes.